### PR TITLE
Add support for URLs in DUD_LOAD_RULE_PATHS.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "Scrapy >= 2.7.0",
+    "treq >= 21.5.0",
     "url-matcher >= 0.5.0",
     "w3lib >= 1.22.0",
 ]
@@ -46,6 +47,7 @@ multi_line_output = 3
 [[tool.mypy.overrides]]
 module = [
     "scrapy.*",
+    "treq.*",
     "url_matcher.*",
 ]
 ignore_missing_imports = true

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py,pre-commit,mypy,docs,twinecheck
 [testenv]
 deps =
     pytest
+    pytest-asyncio
     pytest-cov
 commands =
     py.test \
@@ -17,6 +18,7 @@ basepython = python3.8
 deps =
     {[testenv]deps}
     Scrapy==2.7.0
+    treq==21.5.0
     url-matcher==0.5.0
     w3lib==1.22.0
 


### PR DESCRIPTION
This uses `treq` for downloading, but there are many other options so this is open for discussion.

* Any sync function (so `requests`). Pros: synchronous requests simplify the code. Cons: synchronous may be bad?
* Any async function (listed below). Pros: can run in parallel if we want, doesn't block (is this important?). Cons: makes the code more complicated, though all DUD code is self-contained and so doesn't influence the user code design.
* Scrapy downloader. Pros: reuses Scrapy (not a benefit by itself I think?), easy parallel downloading (I think), better logging and error handling etc. Cons: `UrlCanonicalizer()` is currently decoupled from Scrapy.
* `treq`. Pros: straightforward. Cons: additional dep.
* `aiohttp`. Pros: just a more modern thing. Cons: additional dep, requires the asyncio reactor which is a blocker.