### PR TITLE
remove item from being logged in DropItem to prevent dupe logs

### DIFF
--- a/duplicate_url_discarder/pipelines.py
+++ b/duplicate_url_discarder/pipelines.py
@@ -36,7 +36,7 @@ class DuplicateUrlDiscarderPipeline:
 
         signature = item_signature(ItemAdapter(item), item_attributes)
         if signature in self._seen_item_signatures:
-            raise DropItem(f"Dropping item that was already seen before:\n{item}")
+            raise DropItem("Dropping item that was already seen before.")
 
         self._seen_item_signatures.add(signature)
         return item


### PR DESCRIPTION
Missed the fact that by default, Scrapy already logs the item that was dropped. Ref: https://github.com/scrapy/scrapy/blob/master/scrapy/logformatter.py#L22.

This PR prevents the dropped item from being logged twice:

<img width="906" alt="image" src="https://github.com/user-attachments/assets/73f4d909-e07a-495e-8f2a-a597e6ac1a34">
